### PR TITLE
Bump getml version to 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ classifiers = [
 dependencies = [
     "pyyaml~=6.0",
     "mlflow~=2.20.3",
-    "getml==1.5.0",
+    "getml==1.5.1",
     "typing-extensions>=4.12.2",
 ]
 


### PR DESCRIPTION
[getml.com repo](https://github.com/getml/getml.com) depends on:
```
"getml==1.5.1",
"getml-mlflow @ git+https://github.com/getml/getml-mlflow.git"
 ```
 
 When trying to sync the dependencies to update the docs to version 1.5.1, the version mismatch occurs:

![image](https://github.com/user-attachments/assets/25ba836f-e399-463f-b293-916dd07bbb3a)
